### PR TITLE
Inclusão dos testes das entidades

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -78,11 +78,7 @@
             <groupId>org.thymeleaf.extras</groupId>
             <artifactId>thymeleaf-extras-java8time</artifactId>
         </dependency>
-        <!-- https://mvnrepository.com/artifact/org.webjars/jquery -->
-        <dependency>
-            <groupId>org.webjars</groupId>
-            <artifactId>jquery</artifactId>
-        </dependency>
+      
 
 
     </dependencies>

--- a/src/test/java/local/locadora/entities/ClienteEntityTest.java
+++ b/src/test/java/local/locadora/entities/ClienteEntityTest.java
@@ -8,13 +8,28 @@ import javax.validation.ConstraintViolation;
 import javax.validation.Validation;
 import javax.validation.Validator;
 import javax.validation.ValidatorFactory;
+import local.locadora.dao.ClienteDAO;
 import org.hibernate.validator.internal.engine.ConstraintViolationImpl;
+import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase.Replace;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.test.context.junit4.SpringRunner;
+
+//@RunWith(SpringRunner.class)
+//@DataJpaTest
+//@AutoConfigureTestDatabase(replace = Replace.NONE)
 
 public class ClienteEntityTest {
 
     private static Validator validator;
+    
+    @Autowired
+    private ClienteDAO clienteRepository;
 
     @Before
     public void setUp() {
@@ -34,5 +49,30 @@ public class ClienteEntityTest {
        // }
 
         assertThat(message,is("Um nome deve possuir entre 4 e 50 caracteres"));
+    }
+    
+    @Test
+    public void testNomeDeveSerUnico() {
+        
+        try {
+            Cliente cliente1 = new Cliente("Mussum");
+            Cliente clienteSave1 = clienteRepository.save(cliente1);
+            
+            Cliente cliente2 = new Cliente("Mussum");
+            Cliente clienteSave2 = clienteRepository.save(cliente2);
+            
+            Assert.fail();
+        } catch (Exception e) {
+        }
+    }
+    
+    @Test
+    public void testNomeNaoDeveAceitarEspacosEmBrancoNoInicioENoFim() {
+        
+        try {
+            Cliente cliente = new Cliente(" Mussum ");
+            Assert.fail();
+        } catch (Exception e) {
+        }
     }
 }

--- a/src/test/java/local/locadora/entities/FilmeEntityTest.java
+++ b/src/test/java/local/locadora/entities/FilmeEntityTest.java
@@ -1,0 +1,77 @@
+/*
+ * To change this license header, choose License Headers in Project Properties.
+ * To change this template file, choose Tools | Templates
+ * and open the template in the editor.
+ */
+package local.locadora.entities;
+
+import local.locadora.dao.FilmeDAO;
+import org.junit.Assert;
+import static org.junit.Assert.assertEquals;
+import org.junit.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+/**
+ *
+ * @author aluno
+ */
+public class FilmeEntityTest {
+    
+    @Autowired
+    private FilmeDAO filmeRepository;
+    
+    @Test
+    public void testNomeDeveSerUnico() {
+        
+        try {
+            Filme filme1 = new Filme("FilmeQualquer", 10, 4.0);
+            Filme filmeSave1 = filmeRepository.save(filme1);
+            
+            Filme filme2 = new Filme("FilmeQualquer", 10, 4.0);
+            Filme filmeSave2 = filmeRepository.save(filme2);
+            
+            Assert.fail();
+        } catch (Exception e) {
+        }
+    }
+    
+    @Test
+    public void testNomeDevePossuirEntre2E100Caracteres () {
+        
+        try {
+            Filme filme = new Filme("F", 10, 4.00);
+        } catch (Exception e) {
+            assertEquals(e.getMessage(), "Um filme deve possuir entre 2 e 100 caracteres");
+        }
+    }
+    
+    @Test
+    public void testEstoqueDeveSerPositivo () {
+        
+        try {
+            Filme filme = new Filme("Filme1", -1, 4.00);
+        } catch (Exception e) {
+            assertEquals(e.getMessage(), "O Estoque deve ser positivo");
+        }
+    }
+    
+    @Test
+    public void testPrecoDeveSerPositivo () {
+        
+        try {
+            Filme filme = new Filme("Filme1", 10, -1d);
+        } catch (Exception e) {
+            assertEquals(e.getMessage(), "O Valor da locação deve ser positivo");
+        }
+    }
+    
+    @Test
+    public void testPrecoCom2Digitos () {
+        
+        try {
+            Filme filme = new Filme("Filme1", 10, 400.00);
+        } catch (Exception e) {
+            assertEquals(e.getMessage(), "O Preço deve ter no máximo dois dígitos");
+        }
+    }
+}

--- a/src/test/java/local/locadora/entities/LocacaoEntityTest.java
+++ b/src/test/java/local/locadora/entities/LocacaoEntityTest.java
@@ -1,0 +1,62 @@
+/*
+ * To change this license header, choose License Headers in Project Properties.
+ * To change this template file, choose Tools | Templates
+ * and open the template in the editor.
+ */
+package local.locadora.entities;
+
+import static org.junit.Assert.assertEquals;
+import org.junit.Test;
+
+/**
+ *
+ * @author aluno
+ */
+public class LocacaoEntityTest {
+    
+    @Test
+    public void testLocacaoNaoPodeSerRealizadaSemCliente() {
+        
+        try {
+            Locacao locacao = new Locacao();
+            locacao.setCliente(null);
+        } catch (Exception e) {
+            assertEquals(e.getMessage(), "Um cliente deve ser selecionado");
+        }
+    }
+    
+    @Test
+    public void testLocacaoDevePossuirPeloMenos1Filme() {
+        
+        try {
+            Locacao locacao = new Locacao();
+            locacao.setFilmes(null);
+        } catch (Exception e) {
+            assertEquals(e.getMessage(), "Pelo menos um filme deve ser selecionado");
+        }
+    }
+    
+    @Test
+    public void testLocacaoDevePossuirDataDeLocacao() {
+        
+        try {
+            Locacao locacao = new Locacao();
+            locacao.setDataLocacao(null);
+        } catch (Exception e) {
+            assertEquals(e.getMessage(), "A data de locação não deve ser nula");
+        }
+    }
+    
+    @Test
+    public void testLocacaoDevePossuirDataDeRetorno() {
+        
+        try {
+            Locacao locacao = new Locacao();
+            locacao.setDataRetorno(null);
+        } catch (Exception e) {
+            assertEquals(e.getMessage(), "A data de retorno não deve ser nula");
+        }
+    }
+    
+    
+}


### PR DESCRIPTION
Neste commit foram incluídas as classes de teste FilmeEntityTest.java e LocacaoEntityTest.java, além da alteração (adição de mais métodos) na classe ClienteEntityTest.java.

Na classe FilmeEntityTest.java foram testados:

- A inclusão de filmes com o mesmo nome (inclui DAO);
- A inclusão de um filme com o nome contendo apenas um caractere;
- A inclusão de um filme com estoque negativo;
- A inclusão de um filme com preço de locação negativo;
- A inclusão de um filme com o preço contendo mais de 2 dígitos;

Na classe LocacaoEntityTest.java foram testados:

- A inclusão de uma locação sem cliente;
- A inclusão de uma locação sem filmes;
- A inclusão de uma locação sem data de locação;
- A inclusão de uma locação sem data de retorno;

E na classe ClienteEntityTest.java foram testados (além do que já tinha):

- A inclusão de clientes com o mesmo nome (inclui DAO);
- A inclusão de um cliente com espaço no início e no fim do nome (falhou por bug do sistema);

Obs: Entre os testes citados acima, aqueles que incluem repositórios (DAO) falharam por erros de dependências. Apenas um teste falhou por bug do sistema, e o restante dos testes foram aprovados.
